### PR TITLE
Disable external entity expansion

### DIFF
--- a/CBTForceBalancer/src/BFB/IO/XMLReader.java
+++ b/CBTForceBalancer/src/BFB/IO/XMLReader.java
@@ -40,8 +40,16 @@ public class XMLReader {
     frmBase Parent;
 
     Document load;
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilderFactory dbf;
     DocumentBuilder db;
+
+    public XMLReader() {
+        dbf = DocumentBuilderFactory.newInstance();
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+        dbf.setExpandEntityReferences(false);
+    }
 
     public Force[] ReadFile( frmBase parent, String filename ) throws Exception {
         System.out.println("Loading Forces from " + filename);


### PR DESCRIPTION
XMLReader was previously vulnerable to XXE attacks, which I was able to validate with a proof-of-concept. This PR is a backport of https://github.com/WEKarnesky/sswlib/commit/6ae74cd215e20c0f396de529f8b946487284af52 that securely configures the XML parser to disable external entities.